### PR TITLE
#491 specific s3 upload exception on import

### DIFF
--- a/src/main/scala/no/ndla/imageapi/controller/InternController.scala
+++ b/src/main/scala/no/ndla/imageapi/controller/InternController.scala
@@ -57,8 +57,6 @@ trait InternController {
           Ok(converterService.asApiImageMetaInformationWithDomainUrl(imageMeta))
         }
         case Failure(s: S3UploadException) => {
-          contentType = formats("json")
-          logger.info(s"S3 Fail $s")
           val errMsg = s"Import of node with external_id $imageId failed after ${System.currentTimeMillis - start} ms with error: ${s.getMessage}\n"
           logger.warn(errMsg, s)
           GatewayTimeout(body = Error(Error.GATEWAY_TIMEOUT, errMsg))

--- a/src/main/scala/no/ndla/imageapi/controller/InternController.scala
+++ b/src/main/scala/no/ndla/imageapi/controller/InternController.scala
@@ -8,11 +8,13 @@
 
 package no.ndla.imageapi.controller
 
+import no.ndla.imageapi.model.S3UploadException
 import no.ndla.imageapi.model.api.Error
 import no.ndla.imageapi.repository.ImageRepository
 import no.ndla.imageapi.service.search.IndexBuilderService
 import no.ndla.imageapi.service.{ConverterService, ImportService}
-import org.scalatra.{InternalServerError, Ok}
+import org.json4s.{DefaultFormats, Formats}
+import org.scalatra.{GatewayTimeout, InternalServerError, NotFound, Ok}
 
 import scala.util.{Failure, Success}
 
@@ -21,6 +23,8 @@ trait InternController {
   val internController: InternController
 
   class InternController extends NdlaController {
+
+    protected implicit override val jsonFormats: Formats = DefaultFormats
 
     post("/index") {
       indexBuilderService.indexDocuments match {
@@ -39,8 +43,8 @@ trait InternController {
     get("/extern/:image_id") {
       val externalId = params("image_id")
       imageRepository.withExternalId(externalId) match {
-        case Some(image) => converterService.asApiImageMetaInformationWithDomainUrl(image)
-        case None => halt(status = 404, body = Error(Error.NOT_FOUND, s"Image with external id $externalId not found"))
+        case Some(image) => Ok(converterService.asApiImageMetaInformationWithDomainUrl(image))
+        case None => NotFound(Error(Error.NOT_FOUND, s"Image with external id $externalId not found"))
       }
     }
 
@@ -49,11 +53,20 @@ trait InternController {
       val imageId = params("image_id")
 
       importService.importImage(imageId) match {
-        case Success(imageMeta) => converterService.asApiImageMetaInformationWithDomainUrl(imageMeta)
+        case Success(imageMeta) => {
+          Ok(converterService.asApiImageMetaInformationWithDomainUrl(imageMeta))
+        }
+        case Failure(s: S3UploadException) => {
+          contentType = formats("json")
+          logger.info(s"S3 Fail $s")
+          val errMsg = s"Import of node with external_id $imageId failed after ${System.currentTimeMillis - start} ms with error: ${s.getMessage}\n"
+          logger.warn(errMsg, s)
+          GatewayTimeout(body = Error(Error.GATEWAY_TIMEOUT, errMsg))
+        }
         case Failure(ex: Throwable) => {
           val errMsg = s"Import of node with external_id $imageId failed after ${System.currentTimeMillis - start} ms with error: ${ex.getMessage}\n"
           logger.warn(errMsg, ex)
-          halt(status = 500, body = errMsg)
+          InternalServerError(body = errMsg)
         }
       }
     }

--- a/src/main/scala/no/ndla/imageapi/model/NDLAErrors.scala
+++ b/src/main/scala/no/ndla/imageapi/model/NDLAErrors.scala
@@ -12,9 +12,15 @@ import io.searchbox.client.JestResult
 
 
 class ImageNotFoundException(message: String) extends RuntimeException(message)
+
 class AccessDeniedException(message: String) extends RuntimeException(message)
+
 class ValidationException(message: String = "Validation error", val errors: Seq[ValidationMessage]) extends RuntimeException(message)
+
 case class ValidationMessage(field: String, message: String)
+
 class NdlaSearchException(jestResponse: JestResult) extends RuntimeException(jestResponse.getErrorMessage) {
   def getResponse: JestResult = jestResponse
 }
+
+class S3UploadException(message: String) extends RuntimeException(message)

--- a/src/main/scala/no/ndla/imageapi/model/api/Error.scala
+++ b/src/main/scala/no/ndla/imageapi/model/api/Error.scala
@@ -27,6 +27,7 @@ object Error {
   val VALIDATION = "VALIDATION"
   val FILE_TOO_BIG = "FILE TOO BIG"
   val ACCESS_DENIED = "ACCESS DENIED"
+  val GATEWAY_TIMEOUT =  "GATEWAY TIMEOUT"
 
   val GenericError = Error(GENERIC, s"Ooops. Something we didn't anticipate occured. We have logged the error, and will look into it. But feel free to contact ${ImageApiProperties.ContactEmail} if the error persists.")
   val IndexMissingError = Error(INDEX_MISSING, s"Ooops. Our search index is not available at the moment, but we are trying to recreate it. Please try again in a few minutes. Feel free to contact ${ImageApiProperties.ContactEmail} if the error persists.")

--- a/src/main/scala/no/ndla/imageapi/service/ImportService.scala
+++ b/src/main/scala/no/ndla/imageapi/service/ImportService.scala
@@ -29,17 +29,11 @@ trait ImportService {
 
     def importImage(imageId: String): Try[domain.ImageMetaInformation] = {
       val imported = migrationApiClient.getMetaDataForImage(imageId).map(upload)
-
-      imported match {
-        case Success(imp) => {
-          imp.foreach(indexBuilderService.indexDocument)
-          imp
-        }
-        case Failure(f) => Failure(f)
-      }
+      imported.foreach(indexBuilderService.indexDocument)
+      imported
     }
 
-    def upload(imageMeta: MainImageImport): Try[domain.ImageMetaInformation] = {
+    def upload(imageMeta: MainImageImport): domain.ImageMetaInformation = {
       val start = System.currentTimeMillis
 
       val tags = tagsService.forImage(imageMeta.mainImage.nid) match {
@@ -107,7 +101,7 @@ trait ImportService {
         }
       }
 
-      Success(persistedImageMetaInformation)
+      persistedImageMetaInformation
     }
 
     private def languageCodeSupported(languageCode: String) =

--- a/src/test/scala/no/ndla/imageapi/controller/InternControllerTest.scala
+++ b/src/test/scala/no/ndla/imageapi/controller/InternControllerTest.scala
@@ -8,7 +8,7 @@
 
 package no.ndla.imageapi.controller
 
-import no.ndla.imageapi.model.{api, domain}
+import no.ndla.imageapi.model.{S3UploadException, api, domain}
 import no.ndla.imageapi.{ImageApiProperties, TestEnvironment, UnitSuite}
 import org.joda.time.{DateTime, DateTimeZone}
 import org.json4s.jackson.Serialization._
@@ -64,6 +64,14 @@ class InternControllerTest extends UnitSuite with ScalatraSuite with TestEnviron
     post("/import/123") {
       status should equal (500)
       body indexOf "external_id 123 failed after" should be > 0
+    }
+  }
+
+  test("That POST /import/123 returns 504 with error message when import failed on S3 upload") {
+    when(importService.importImage(eqTo("123"))).thenThrow(new S3UploadException(s"Upload of image:[name] to S3 failed."))
+    post("/import/123") {
+      status should equal (504)
+      body indexOf "Upload of image:[name] to S3 failed" should be > 0
     }
   }
 


### PR DESCRIPTION
Frem til nå så har feilende S3 upload blitt fullstendig forbigått i stillhet, og metadata har blitt lagt i databasen selv om bildet ikke er lastet opp til S3 bøtta. 
Nå returneres det en 504 istedet, og avbryter før db persistering. 