### PR TITLE
fetch raw image instead of metadata in health check

### DIFF
--- a/src/main/scala/no/ndla/imageapi/controller/HealthController.scala
+++ b/src/main/scala/no/ndla/imageapi/controller/HealthController.scala
@@ -30,7 +30,7 @@ trait HealthController {
     def getImageUrl(body: String): (Option[String], Long) = {
       val json = JsonParser.parse(body).extract[SearchResult]
       json.results.headOption match {
-        case Some(result: ImageMetaSummary) => (Some(result.metaUrl), json.totalCount)
+        case Some(result: ImageMetaSummary) => (Some(result.previewUrl), json.totalCount)
         case _ => (None,json.totalCount)
       }
     }

--- a/src/test/scala/no/ndla/imageapi/controller/HealthControllerTest.scala
+++ b/src/test/scala/no/ndla/imageapi/controller/HealthControllerTest.scala
@@ -101,7 +101,7 @@ class HealthControllerTest extends UnitSuite with TestEnvironment with ScalatraF
   addServlet(controller, "/")
 
   test("that url is fetched properly") {
-    val expectedUrl = "http://0.0.0.0/image-api/v2/images/1"
+    val expectedUrl = "http://0.0.0.0/image-api/raw/sx873733_1.jpg"
     val (url, totalCount) = controller.getImageUrl(imageSearchBody)
 
     url should equal(Some(expectedUrl))


### PR DESCRIPTION
Overså at det var `metaUrl` som ble brukt i forrige PR, i stedet for `previewUrl` som egentlig skal brukes