### PR TITLE
NDLANO/Issues#501 Adds PATCH endpoint

### DIFF
--- a/src/main/scala/no/ndla/imageapi/controller/ImageControllerV2.scala
+++ b/src/main/scala/no/ndla/imageapi/controller/ImageControllerV2.scala
@@ -177,7 +177,10 @@ trait ImageControllerV2 {
     patch("/:image_id", operation(updateImage)) {
       authRole.assertHasRole(RoleWithWriteAccess)
       val imageId = long("image_id")
-      writeService.updateImage(imageId, extract[UpdateImageMetaInformation](request.body))
+      writeService.updateImage(imageId, extract[UpdateImageMetaInformation](request.body)) match {
+        case Success(imageMeta) => imageMeta
+        case Failure(e) => errorHandler(e)
+      }
     }
 
   }

--- a/src/main/scala/no/ndla/imageapi/controller/ImageControllerV2.scala
+++ b/src/main/scala/no/ndla/imageapi/controller/ImageControllerV2.scala
@@ -97,6 +97,18 @@ trait ImageControllerV2 {
       )
         authorizations "oauth2"
         responseMessages(response400, response403, response413, response500))
+    val updateImage =
+      (apiOperation[ImageMetaInformationV2]("newImage")
+        summary "Update existing image with meta data"
+        notes "Updates an existing image with meta data."
+        consumes "form-data"
+        parameters(
+        headerParam[Option[String]]("X-Correlation-ID").description("User supplied correlation-id. May be omitted."),
+        headerParam[Option[String]]("app-key").description("Your app-key. May be omitted to access api anonymously, but rate limiting may apply on anonymous access."),
+        formParam[String]("metadata").description("The metadata for the image file to submit. See UpdateImageMetaInformation."),
+      )
+        authorizations "oauth2"
+        responseMessages(response400, response403, response500))
 
     configureMultipartHandling(MultipartConfig(maxFileSize = Some(MaxImageFileSizeBytes)))
 
@@ -162,7 +174,7 @@ trait ImageControllerV2 {
       }
     }
 
-    put("/:image_id") { //TODO: Add operation/doc
+    patch("/:image_id", operation(updateImage)) {
       authRole.assertHasRole(RoleWithWriteAccess)
       val imageId = long("image_id")
       writeService.updateImage(imageId, extract[UpdateImageMetaInformation](request.body))

--- a/src/main/scala/no/ndla/imageapi/controller/ImageControllerV2.scala
+++ b/src/main/scala/no/ndla/imageapi/controller/ImageControllerV2.scala
@@ -105,7 +105,7 @@ trait ImageControllerV2 {
         parameters(
         headerParam[Option[String]]("X-Correlation-ID").description("User supplied correlation-id. May be omitted."),
         headerParam[Option[String]]("app-key").description("Your app-key. May be omitted to access api anonymously, but rate limiting may apply on anonymous access."),
-        formParam[String]("metadata").description("The metadata for the image file to submit. See UpdateImageMetaInformation."),
+        bodyParam[UpdateImageMetaInformation]("metadata").description("The metadata for the image file to submit. See UpdateImageMetaInformation."),
       )
         authorizations "oauth2"
         responseMessages(response400, response403, response500))

--- a/src/main/scala/no/ndla/imageapi/controller/InternController.scala
+++ b/src/main/scala/no/ndla/imageapi/controller/InternController.scala
@@ -64,7 +64,7 @@ trait InternController {
       val externalId = params("image_id")
       val language = paramOrNone("language")
       imageRepository.withExternalId(externalId) match {
-        case Some(image) => Ok(converterService.asApiImageMetaInformationWithDomainUrlAndSingleLanguage(image, language))
+        case Some(image) => Ok(converterService.asApiImageMetaInformationWithDomainUrlV2(image, language))
         case None => NotFound(Error(Error.NOT_FOUND, s"Image with external id $externalId not found"))
       }
     }
@@ -75,7 +75,7 @@ trait InternController {
 
       importService.importImage(imageId) match {
         case Success(imageMeta) => {
-          Ok(converterService.asApiImageMetaInformationWithDomainUrlAndSingleLanguage(imageMeta, None))
+          Ok(converterService.asApiImageMetaInformationWithDomainUrlV2(imageMeta, None))
         }
         case Failure(s: S3UploadException) => {
           val errMsg = s"Import of node with external_id $imageId failed after ${System.currentTimeMillis - start} ms with error: ${s.getMessage}\n"

--- a/src/main/scala/no/ndla/imageapi/model/api/UpdateImageMetaInformation.scala
+++ b/src/main/scala/no/ndla/imageapi/model/api/UpdateImageMetaInformation.scala
@@ -1,0 +1,21 @@
+/*
+ * Part of NDLA image_api.
+ * Copyright (C) 2017 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.imageapi.model.api
+
+import org.scalatra.swagger.annotations.{ApiModel, ApiModelProperty}
+
+import scala.annotation.meta.field
+
+@ApiModel(description = "Meta information for the image")
+case class UpdateImageMetaInformation(@(ApiModelProperty@field)(description = "ISO 639-1 code that represents the language used in the request") language: String,
+                                      @(ApiModelProperty@field)(description = "Title for the image") title: Option[String],
+                                      @(ApiModelProperty@field)(description = "Alternative text for the image") alttext: Option[String],
+                                      @(ApiModelProperty@field)(description = "Describes the copyright information for the image") copyright: Option[Copyright],
+                                      @(ApiModelProperty@field)(description = "Searchable tags for the image") tags: Option[Seq[String]],
+                                      @(ApiModelProperty@field)(description = "Caption for the image") caption: Option[String]
+                                     )

--- a/src/main/scala/no/ndla/imageapi/service/ConverterService.scala
+++ b/src/main/scala/no/ndla/imageapi/service/ConverterService.scala
@@ -39,12 +39,12 @@ trait ConverterService {
       api.ImageAltText(domainImageAltText.alttext, domainImageAltText.language)
     }
 
-    def asApiImageMetaInformationWithApplicationUrlAndSingleLanguage(domainImageMetaInformation: domain.ImageMetaInformation, language: Option[String]): Option[api.ImageMetaInformationV2] = {
+    def asApiImageMetaInformationWithApplicationUrlV2(domainImageMetaInformation: domain.ImageMetaInformation, language: Option[String]): Option[api.ImageMetaInformationV2] = {
       val rawPath = ApplicationUrl.get.replace("/v2/images/", "/raw")
       asImageMetaInformationV2(domainImageMetaInformation, language, ApplicationUrl.get, Some(rawPath))
     }
 
-    def asApiImageMetaInformationWithDomainUrlAndSingleLanguage(domainImageMetaInformation: domain.ImageMetaInformation, language: Option[String]): Option[api.ImageMetaInformationV2] = {
+    def asApiImageMetaInformationWithDomainUrlV2(domainImageMetaInformation: domain.ImageMetaInformation, language: Option[String]): Option[api.ImageMetaInformationV2] = {
       asImageMetaInformationV2(domainImageMetaInformation, language, ImageApiProperties.ImageApiUrlBase, Some(ImageApiProperties.RawImageUrlBase))
     }
 

--- a/src/main/scala/no/ndla/imageapi/service/ConverterService.scala
+++ b/src/main/scala/no/ndla/imageapi/service/ConverterService.scala
@@ -141,4 +141,5 @@ trait ConverterService {
     }
 
   }
+
 }

--- a/src/main/scala/no/ndla/imageapi/service/WriteService.scala
+++ b/src/main/scala/no/ndla/imageapi/service/WriteService.scala
@@ -4,9 +4,11 @@ import java.io.ByteArrayInputStream
 import java.lang.Math.max
 
 import com.typesafe.scalalogging.LazyLogging
-import no.ndla.imageapi.model.ValidationException
-import no.ndla.imageapi.model.api.NewImageMetaInformationV2
-import no.ndla.imageapi.model.domain.{Image, ImageMetaInformation}
+import no.ndla.imageapi.auth.User
+import no.ndla.imageapi.model.{ImageNotFoundException, ValidationException}
+import no.ndla.imageapi.model.api.{ImageMetaInformationV2, NewImageMetaInformationV2, UpdateImageMetaInformation}
+import no.ndla.imageapi.model.domain.{Image, ImageMetaInformation, LanguageField}
+import no.ndla.imageapi.model.domain
 import no.ndla.imageapi.repository.ImageRepository
 import no.ndla.imageapi.service.search.IndexService
 import org.scalatra.servlet.FileItem
@@ -14,7 +16,7 @@ import org.scalatra.servlet.FileItem
 import scala.util.{Failure, Random, Success, Try}
 
 trait WriteService {
-  this: ConverterService with ValidationService with ImageRepository with IndexService with ImageStorageService =>
+  this: ConverterService with ValidationService with ImageRepository with IndexService with ImageStorageService with Clock with User =>
   val writeService: WriteService
 
   class WriteService extends LazyLogging {
@@ -51,6 +53,39 @@ trait WriteService {
           imageRepository.delete(imageMeta.id.get)
           Failure(e)
       }
+    }
+
+    private def mergeImages(existing: ImageMetaInformation, toMerge: UpdateImageMetaInformation): domain.ImageMetaInformation = {
+      val now = clock.now()
+      val userId = authUser.id()
+
+      existing.copy(
+        titles = mergeLanguageFields(existing.titles, toMerge.title.toSeq.map(t => converterService.asDomainTitle(t, toMerge.language))),
+        alttexts = mergeLanguageFields(existing.alttexts, toMerge.alttext.toSeq.map(a => converterService.asDomainAltText(a, toMerge.language))),
+        copyright = toMerge.copyright.map(c => converterService.toDomainCopyright(c)).getOrElse(existing.copyright),
+        tags = mergeLanguageFields(existing.tags, toMerge.tags.toSeq.map(t => converterService.toDomainTag(t, toMerge.language))),
+        captions = mergeLanguageFields(existing.captions, toMerge.caption.toSeq.map(c => converterService.toDomainCaption(c, toMerge.language))),
+        updated = now,
+        updatedBy = userId
+      )
+    }
+
+    def updateImage(imageId: Long, image: UpdateImageMetaInformation): Try[ImageMetaInformationV2] = {
+      val updateImage = imageRepository.withId(imageId) match {
+        case None => Failure(new ImageNotFoundException(s"Image with id $imageId found"))
+        case Some(existing) => Success(mergeImages(existing, image))
+      }
+
+      val updatedImage = updateImage.flatMap(validationService.validate)
+        .map(imageMeta => imageRepository.update(imageMeta, imageId))
+        .flatMap(indexService.indexDocument)
+        .map(updatedImage => converterService.asApiImageMetaInformationWithDomainUrlV2(updatedImage, Some(image.language)).get)
+      updatedImage
+    }
+
+    private def mergeLanguageFields[A <: LanguageField[String]](existing: Seq[A], updated: Seq[A]): Seq[A] = {
+      val toKeep = existing.filterNot(item => updated.map(_.language).contains(item.language))
+      (toKeep ++ updated).filterNot(_.value.isEmpty)
     }
 
     private[service] def getFileExtension(fileName: String): Option[String] = {

--- a/src/main/scala/no/ndla/imageapi/service/WriteService.scala
+++ b/src/main/scala/no/ndla/imageapi/service/WriteService.scala
@@ -81,14 +81,13 @@ trait WriteService {
         case Some(existing) => Success(mergeImages(existing, image))
       }
 
-      val updatedImage = updateImage.flatMap(validationService.validate)
+      updateImage.flatMap(validationService.validate)
         .map(imageMeta => imageRepository.update(imageMeta, imageId))
         .flatMap(indexService.indexDocument)
         .map(updatedImage => converterService.asApiImageMetaInformationWithDomainUrlV2(updatedImage, Some(image.language)).get)
-      updatedImage
     }
 
-    private def mergeLanguageFields[A <: LanguageField[String]](existing: Seq[A], updated: Seq[A]): Seq[A] = {
+    private[service] def mergeLanguageFields[A <: LanguageField[String]](existing: Seq[A], updated: Seq[A]): Seq[A] = {
       val toKeep = existing.filterNot(item => updated.map(_.language).contains(item.language))
       (toKeep ++ updated).filterNot(_.value.isEmpty)
     }

--- a/src/main/scala/no/ndla/imageapi/service/WriteService.scala
+++ b/src/main/scala/no/ndla/imageapi/service/WriteService.scala
@@ -55,7 +55,7 @@ trait WriteService {
       }
     }
 
-    private def mergeImages(existing: ImageMetaInformation, toMerge: UpdateImageMetaInformation): domain.ImageMetaInformation = {
+    private[service] def mergeImages(existing: ImageMetaInformation, toMerge: UpdateImageMetaInformation): domain.ImageMetaInformation = {
       val now = clock.now()
       val userId = authUser.id()
 

--- a/src/main/scala/no/ndla/imageapi/service/WriteService.scala
+++ b/src/main/scala/no/ndla/imageapi/service/WriteService.scala
@@ -22,14 +22,14 @@ trait WriteService {
   class WriteService extends LazyLogging {
     def storeNewImage(newImage: NewImageMetaInformationV2, file: FileItem): Try[ImageMetaInformation] = {
       validationService.validateImageFile(file) match {
-        case Some(validationMessage) => return Failure(new ValidationException(errors=Seq(validationMessage)))
+        case Some(validationMessage) => return Failure(new ValidationException(errors = Seq(validationMessage)))
         case _ =>
       }
 
       val domainImage = uploadImage(file).map(uploadedImage =>
-          converterService.asDomainImageMetaInformationV2(newImage, uploadedImage)) match {
-            case Failure(e) => return Failure(e)
-            case Success(image) => image
+        converterService.asDomainImageMetaInformationV2(newImage, uploadedImage)) match {
+        case Failure(e) => return Failure(e)
+        case Success(image) => image
       }
 
       validationService.validate(domainImage) match {
@@ -116,4 +116,5 @@ trait WriteService {
     }
 
   }
+
 }

--- a/src/main/scala/no/ndla/imageapi/service/WriteService.scala
+++ b/src/main/scala/no/ndla/imageapi/service/WriteService.scala
@@ -63,11 +63,16 @@ trait WriteService {
         titles = mergeLanguageFields(existing.titles, toMerge.title.toSeq.map(t => converterService.asDomainTitle(t, toMerge.language))),
         alttexts = mergeLanguageFields(existing.alttexts, toMerge.alttext.toSeq.map(a => converterService.asDomainAltText(a, toMerge.language))),
         copyright = toMerge.copyright.map(c => converterService.toDomainCopyright(c)).getOrElse(existing.copyright),
-        tags = mergeLanguageFields(existing.tags, toMerge.tags.toSeq.map(t => converterService.toDomainTag(t, toMerge.language))),
+        tags = mergeTags(existing.tags, toMerge.tags.toSeq.map(t => converterService.toDomainTag(t, toMerge.language))),
         captions = mergeLanguageFields(existing.captions, toMerge.caption.toSeq.map(c => converterService.toDomainCaption(c, toMerge.language))),
         updated = now,
         updatedBy = userId
       )
+    }
+
+    private def mergeTags(existing: Seq[domain.ImageTag], updated: Seq[domain.ImageTag]): Seq[domain.ImageTag] = {
+      val toKeep = existing.filterNot(item => updated.map(_.language).contains(item.language))
+      (toKeep ++ updated).filterNot(_.tags.isEmpty)
     }
 
     def updateImage(imageId: Long, image: UpdateImageMetaInformation): Try[ImageMetaInformationV2] = {

--- a/src/test/scala/no/ndla/imageapi/TestData.scala
+++ b/src/test/scala/no/ndla/imageapi/TestData.scala
@@ -13,6 +13,7 @@ import java.io.InputStream
 import javax.imageio.ImageIO
 
 import no.ndla.imageapi.integration.{ImageAuthor, ImageMeta, MainImageImport}
+import no.ndla.imageapi.model.api
 import no.ndla.imageapi.model.domain._
 import org.joda.time.{DateTime, DateTimeZone}
 
@@ -30,6 +31,11 @@ object TestData {
     "Elg.jpg", 2865539, "image/jpeg",
     Copyright(ByNcSa, "http://www.scanpix.no", List(Author("Fotograf", "Test Testesen"))),
     List(ImageTag(List("rovdyr", "elg"), "nb")), List(ImageCaption("Elg i busk", "nb")), "ndla124", updated())
+
+  val apiElg = api.ImageMetaInformationV2("1", "Elg.jpg", api.ImageTitle("Elg i busk", "nb"), api.ImageAltText("Elg i busk", "nb"),
+    "Elg.jpg", 2865539, "image/jpeg", api.Copyright(api.License("by-nc-sa", "Creative Commons Attribution-NonCommercial-ShareAlike 2.0 Generic",
+    Some("https://creativecommons.org/licenses/by-nc-sa/2.0/")), "http://www.scanpix.no", List(api.Author("Fotograf", "Test Testesen"))),
+    api.ImageTag(List("rovdyr", "elg"), "nb"), api.ImageCaption("Elg i busk", "nb"), List("nb"))
 
   val bjorn = ImageMetaInformation(Some(2), List(ImageTitle("Bjørn i busk", "nb")),List(ImageAltText("Elg i busk", "nb")),
     "Bjørn.jpg", 141134, "image/jpeg",

--- a/src/test/scala/no/ndla/imageapi/controller/ImageControllerV2Test.scala
+++ b/src/test/scala/no/ndla/imageapi/controller/ImageControllerV2Test.scala
@@ -19,7 +19,6 @@ import org.json4s.DefaultFormats
 import org.json4s.native.JsonParser
 import org.mockito.Matchers._
 import org.mockito.Mockito._
-import org.mockito.invocation.InvocationOnMock
 import org.scalatra.servlet.FileItem
 import org.scalatra.test.Uploadable
 import org.scalatra.test.scalatest.ScalatraSuite

--- a/src/test/scala/no/ndla/imageapi/service/ConverterServiceTest.scala
+++ b/src/test/scala/no/ndla/imageapi/service/ConverterServiceTest.scala
@@ -51,7 +51,7 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
   }
 
   test("That asApiImageMetaInformationWithDomainUrl returns links with domain urls") {
-    val api = converterService.asApiImageMetaInformationWithDomainUrlAndSingleLanguage(DefaultImageMetaInformation, Some("nb"))
+    val api = converterService.asApiImageMetaInformationWithDomainUrlV2(DefaultImageMetaInformation, Some("nb"))
     api.get.metaUrl should equal (s"${ImageApiProperties.ImageApiUrlBase}1")
     api.get.imageUrl should equal (s"${ImageApiProperties.RawImageUrlBase}/123.png")
   }
@@ -59,7 +59,7 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
   test("That asApiImageMetaInformationWithApplicationUrlAndSingleLanguage returns links with applicationUrl") {
     setApplicationUrl()
 
-    val api = converterService.asApiImageMetaInformationWithApplicationUrlAndSingleLanguage(DefaultImageMetaInformation, None)
+    val api = converterService.asApiImageMetaInformationWithApplicationUrlV2(DefaultImageMetaInformation, None)
     api.get.metaUrl should equal ("http://image-api/v2/images/1")
     api.get.imageUrl should equal ("http://image-api/raw/123.png")
   }
@@ -67,14 +67,14 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
   test("That asApiImageMetaInformationWithDomainUrlAndSingleLanguage returns links with domain urls") {
     setApplicationUrl()
 
-    val api = converterService.asApiImageMetaInformationWithDomainUrlAndSingleLanguage(DefaultImageMetaInformation, None)
+    val api = converterService.asApiImageMetaInformationWithDomainUrlV2(DefaultImageMetaInformation, None)
     api.get.metaUrl should equal ("http://api-gateway.ndla-local/image-api/v2/images/1")
     api.get.imageUrl should equal ("http://api-gateway.ndla-local/image-api/raw/123.png")
   }
 
   test("That asApiImageMetaInformationWithApplicationUrlAndSingleLanguage returns links even if language is not supported") {
     setApplicationUrl()
-    val api = converterService.asApiImageMetaInformationWithApplicationUrlAndSingleLanguage(DefaultImageMetaInformation, Some("RandomLangauge"))
+    val api = converterService.asApiImageMetaInformationWithApplicationUrlV2(DefaultImageMetaInformation, Some("RandomLangauge"))
 
     api.get.metaUrl should equal ("http://image-api/v2/images/1")
     api.get.imageUrl should equal ("http://image-api/raw/123.png")
@@ -83,7 +83,7 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
   test("That asApiImageMetaInformationWithDomainUrlAndSingleLanguage returns links even if language is not supported") {
     setApplicationUrl()
 
-    val api = converterService.asApiImageMetaInformationWithDomainUrlAndSingleLanguage(DefaultImageMetaInformation, Some("RandomLangauge"))
+    val api = converterService.asApiImageMetaInformationWithDomainUrlV2(DefaultImageMetaInformation, Some("RandomLangauge"))
     api.get.metaUrl should equal ("http://api-gateway.ndla-local/image-api/v2/images/1")
     api.get.imageUrl should equal ("http://api-gateway.ndla-local/image-api/raw/123.png")
   }

--- a/src/test/scala/no/ndla/imageapi/service/WriteServiceTest.scala
+++ b/src/test/scala/no/ndla/imageapi/service/WriteServiceTest.scala
@@ -13,6 +13,7 @@ import javax.servlet.http.HttpServletRequest
 
 import no.ndla.imageapi.model.ValidationException
 import no.ndla.imageapi.model.api._
+import no.ndla.imageapi.model.domain
 import no.ndla.imageapi.model.domain.{Image, ImageMetaInformation}
 import no.ndla.imageapi.{TestEnvironment, UnitSuite}
 import no.ndla.network.ApplicationUrl
@@ -160,5 +161,60 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     domain.updatedBy should equal ("ndla54321")
     domain.updated should equal(updated())
   }
+  //TODO: mergeImages, mergeTags, updateImage
+
+  test("That mergeLanguageFields returns original list when updated is empty") {
+    val existing = Seq(domain.ImageTitle("Tittel 1", "nb"), domain.ImageTitle("Tittel 2", "nn"), domain.ImageTitle("Tittel 3", "unknown"))
+    writeService.mergeLanguageFields(existing, Seq()) should equal(existing)
+  }
+  test("That mergeLanguageFields updated the english title only when specified") {
+    val tittel1 = domain.ImageTitle("Tittel 1", "nb")
+    val tittel2 = domain.ImageTitle("Tittel 2", "nn")
+    val tittel3 = domain.ImageTitle("Tittel 3", "en")
+    val oppdatertTittel3 = domain.ImageTitle("Title 3 in english", "en")
+
+    val existing = Seq(tittel1, tittel2, tittel3)
+    val updated = Seq(oppdatertTittel3)
+
+    writeService.mergeLanguageFields(existing, updated) should equal(Seq(tittel1, tittel2, oppdatertTittel3))
+  }
+
+  test("That mergeLanguageFields removes a title that is empty") {
+    val tittel1 = domain.ImageTitle("Tittel 1", "nb")
+    val tittel2 = domain.ImageTitle("Tittel 2", "nn")
+    val tittel3 = domain.ImageTitle("Tittel 3", "en")
+    val tittelToRemove = domain.ImageTitle("", "nn")
+
+    val existing = Seq(tittel1, tittel2, tittel3)
+    val updated = Seq(tittelToRemove)
+
+    writeService.mergeLanguageFields(existing, updated) should equal(Seq(tittel1, tittel3))
+  }
+
+  test("That mergeLanguageFields updates the title with unknown language specified") {
+    val tittel1 = domain.ImageTitle("Tittel 1", "nb")
+    val tittel2 = domain.ImageTitle("Tittel 2", "unknown")
+    val tittel3 = domain.ImageTitle("Tittel 3", "en")
+    val oppdatertTittel2 = domain.ImageTitle("Tittel 2 er oppdatert", "unknown")
+
+    val existing = Seq(tittel1, tittel2, tittel3)
+    val updated = Seq(oppdatertTittel2)
+
+    writeService.mergeLanguageFields(existing, updated) should equal(Seq(tittel1, tittel3, oppdatertTittel2))
+  }
+
+  test("That mergeLanguageFields also updates the correct content") {
+    val desc1 = domain.ImageAltText("Beskrivelse 1", "nb")
+    val desc2 = domain.ImageAltText("Beskrivelse 2", "unknown")
+    val desc3 = domain.ImageAltText("Beskrivelse 3", "en")
+    val oppdatertDesc2 = domain.ImageAltText("Beskrivelse 2 er oppdatert", "unknown")
+
+    val existing = Seq(desc1, desc2, desc3)
+    val updated = Seq(oppdatertDesc2)
+
+    writeService.mergeLanguageFields(existing, updated) should equal(Seq(desc1, desc3, oppdatertDesc2))
+  }
+
+
 
 }

--- a/src/test/scala/no/ndla/imageapi/service/WriteServiceTest.scala
+++ b/src/test/scala/no/ndla/imageapi/service/WriteServiceTest.scala
@@ -167,6 +167,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     val existing = Seq(domain.ImageTitle("Tittel 1", "nb"), domain.ImageTitle("Tittel 2", "nn"), domain.ImageTitle("Tittel 3", "unknown"))
     writeService.mergeLanguageFields(existing, Seq()) should equal(existing)
   }
+
   test("That mergeLanguageFields updated the english title only when specified") {
     val tittel1 = domain.ImageTitle("Tittel 1", "nb")
     val tittel2 = domain.ImageTitle("Tittel 2", "nn")


### PR DESCRIPTION
Legger til endepunktet `PATCH /<id>`

Som tar metadata som body (`model.api.UpdateImageMetaInformation`)