### PR TITLE
#916: Makes findAllIndexes only return indexes for the component specified

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 **/target
 **/.DS_Store
 /log
+.env

--- a/src/main/scala/no/ndla/imageapi/controller/InternController.scala
+++ b/src/main/scala/no/ndla/imageapi/controller/InternController.scala
@@ -8,6 +8,7 @@
 
 package no.ndla.imageapi.controller
 
+import no.ndla.imageapi.ImageApiProperties
 import no.ndla.imageapi.auth.User
 import no.ndla.imageapi.model.S3UploadException
 import no.ndla.imageapi.model.api.Error
@@ -43,7 +44,7 @@ trait InternController {
 
     delete("/index") {
       def pluralIndex(n: Int) = if (n == 1) "1 index" else s"$n indexes"
-      val deleteResults = indexService.findAllIndexes match {
+      val deleteResults = indexService.findAllIndexes(ImageApiProperties.SearchIndex) match {
         case Failure(f) => halt(status = 500, body = f.getMessage)
         case Success(indexes) => indexes.map(index => {
           logger.info(s"Deleting index $index")

--- a/src/main/scala/no/ndla/imageapi/model/NDLAErrors.scala
+++ b/src/main/scala/no/ndla/imageapi/model/NDLAErrors.scala
@@ -29,8 +29,9 @@ case class NdlaSearchException(rf: RequestFailure) extends RuntimeException(
      |type: ${rf.error.`type`}
    """.stripMargin
 )
+class ResultWindowTooLargeException(message: String) extends RuntimeException(message)
+case class ElasticIndexingException(message: String) extends RuntimeException(message)
 
 class S3UploadException(message: String) extends RuntimeException(message)
 
-class ResultWindowTooLargeException(message: String) extends RuntimeException(message)
 

--- a/src/main/scala/no/ndla/imageapi/service/search/IndexService.scala
+++ b/src/main/scala/no/ndla/imageapi/service/search/IndexService.scala
@@ -55,7 +55,9 @@ trait IndexService {
         }
 
         response match {
-          case Success(_) => Success(imageMetaList.size)
+          case Success(r) =>
+            logger.info(s"Indexed ${imageMetaList.size} documents. No of failed items: ${r.result.failures.size}")
+            Success(imageMetaList.size)
           case Failure(ex) => Failure(ex)
         }
       }
@@ -83,14 +85,16 @@ trait IndexService {
       }
     }
 
-    def findAllIndexes: Try[Seq[String]] = {
+    def findAllIndexes(indexName: String): Try[Seq[String]] = {
       val response = e4sClient.execute{
         catIndices()
       }
 
       response match {
-        case Success(results) => Success(results.result.map(index => index.index))
-        case Failure(ex) => Failure(ex)
+        case Success(results) =>
+          Success(results.result.map(index => index.index).filter(_.startsWith(indexName)))
+        case Failure(ex) =>
+          Failure(ex)
       }
     }
 

--- a/src/main/scala/no/ndla/imageapi/service/search/SearchService.scala
+++ b/src/main/scala/no/ndla/imageapi/service/search/SearchService.scala
@@ -37,7 +37,7 @@ trait SearchService {
     private val noCopyright = boolQuery().not(termQuery("license", "copyrighted"))
 
     def createEmptyIndexIfNoIndexesExist(): Unit = {
-      val noIndexesExist = indexService.findAllIndexes.map(_.isEmpty).getOrElse(true)
+      val noIndexesExist = indexService.findAllIndexes(ImageApiProperties.SearchIndex).map(_.isEmpty).getOrElse(true)
       if (noIndexesExist) {
         indexBuilderService.createEmptyIndex match {
           case Success(_) =>

--- a/src/test/scala/no/ndla/imageapi/controller/InternControllerTest.scala
+++ b/src/test/scala/no/ndla/imageapi/controller/InternControllerTest.scala
@@ -16,6 +16,7 @@ import org.json4s.jackson.Serialization._
 import org.mockito.Matchers
 import org.mockito.Matchers.{eq => eqTo}
 import org.mockito.Mockito._
+import org.mockito.Matchers._
 import org.scalatra.test.scalatest.ScalatraSuite
 
 import scala.util.{Failure, Success}
@@ -94,7 +95,7 @@ class InternControllerTest extends UnitSuite with ScalatraSuite with TestEnviron
   }
 
   test("That DELETE /index removes all indexes") {
-    when(indexService.findAllIndexes).thenReturn(Success(List("index1", "index2", "index3")))
+    when(indexService.findAllIndexes(any[String])).thenReturn(Success(List("index1", "index2", "index3")))
     doReturn(Success("")).when(indexService).deleteIndexWithName(Some("index1"))
     doReturn(Success("")).when(indexService).deleteIndexWithName(Some("index2"))
     doReturn(Success("")).when(indexService).deleteIndexWithName(Some("index3"))
@@ -102,7 +103,7 @@ class InternControllerTest extends UnitSuite with ScalatraSuite with TestEnviron
       status should equal (200)
       body should equal ("Deleted 3 indexes")
     }
-    verify(indexService).findAllIndexes
+    verify(indexService).findAllIndexes(ImageApiProperties.SearchIndex)
     verify(indexService).deleteIndexWithName(Some("index1"))
     verify(indexService).deleteIndexWithName(Some("index2"))
     verify(indexService).deleteIndexWithName(Some("index3"))
@@ -110,7 +111,7 @@ class InternControllerTest extends UnitSuite with ScalatraSuite with TestEnviron
   }
 
   test("That DELETE /index fails if at least one index isn't found, and no indexes are deleted") {
-    doReturn(Failure(new RuntimeException("Failed to find indexes"))).when(indexService).findAllIndexes
+    doReturn(Failure(new RuntimeException("Failed to find indexes"))).when(indexService).findAllIndexes(ImageApiProperties.SearchIndex)
     doReturn(Success("")).when(indexService).deleteIndexWithName(Some("index1"))
     doReturn(Success("")).when(indexService).deleteIndexWithName(Some("index2"))
     doReturn(Success("")).when(indexService).deleteIndexWithName(Some("index3"))
@@ -122,7 +123,7 @@ class InternControllerTest extends UnitSuite with ScalatraSuite with TestEnviron
   }
 
   test("That DELETE /index fails if at least one index couldn't be deleted, but the other indexes are deleted regardless") {
-    when(indexService.findAllIndexes).thenReturn(Success(List("index1", "index2", "index3")))
+    when(indexService.findAllIndexes(any[String])).thenReturn(Success(List("index1", "index2", "index3")))
     doReturn(Success("")).when(indexService).deleteIndexWithName(Some("index1"))
     doReturn(Failure(new RuntimeException("No index with name 'index2' exists"))).when(indexService).deleteIndexWithName(Some("index2"))
     doReturn(Success("")).when(indexService).deleteIndexWithName(Some("index3"))

--- a/src/test/scala/no/ndla/imageapi/service/search/SearchServiceTest.scala
+++ b/src/test/scala/no/ndla/imageapi/service/search/SearchServiceTest.scala
@@ -9,6 +9,7 @@ package no.ndla.imageapi.service.search
 
 import no.ndla.imageapi.{TestEnvironment, UnitSuite}
 import org.mockito.Mockito._
+import org.mockito.Matchers._
 
 import scala.util.Success
 
@@ -17,13 +18,13 @@ class SearchServiceTest extends UnitSuite with TestEnvironment {
   override val searchService = new SearchService
 
   test("That createEmptyIndexIfNoIndexesExist never creates empty index if an index already exists") {
-    when(indexService.findAllIndexes).thenReturn(Success(Seq("index1")))
+    when(indexService.findAllIndexes(any[String])).thenReturn(Success(Seq("index1")))
     searchService.createEmptyIndexIfNoIndexesExist()
     verify(indexBuilderService, never()).createEmptyIndex
   }
 
   test("That createEmptyIndexIfNoIndexesExist creates empty index if no indexes already exists") {
-    when(indexService.findAllIndexes).thenReturn(Success(List.empty))
+    when(indexService.findAllIndexes(any[String])).thenReturn(Success(List.empty))
     when(indexBuilderService.createEmptyIndex).thenReturn(Success(Some("images-123j")))
     searchService.createEmptyIndexIfNoIndexesExist()
     verify(indexBuilderService).createEmptyIndex


### PR DESCRIPTION
Simply filters on the index name, so we dont delete other
indexes when image-api elasticsearch cluster is merged with others
(Also when running locally).