### PR TITLE
#2226: Only create initial scroll-context when provided with '0', 'start', 'first' or 'initial'

### DIFF
--- a/src/main/scala/no/ndla/imageapi/ImageApiProperties.scala
+++ b/src/main/scala/no/ndla/imageapi/ImageApiProperties.scala
@@ -110,7 +110,8 @@ object ImageApiProperties extends LazyLogging {
   val SearchRegion = propOrElse("SEARCH_REGION", "eu-central-1")
   val RunWithSignedSearchRequests = propOrElse("RUN_WITH_SIGNED_SEARCH_REQUESTS", "true").toBoolean
   val ElasticSearchIndexMaxResultWindow = 10000
-  val ElasticSearchScrollKeepAlive = "10s"
+  val ElasticSearchScrollKeepAlive = "1m"
+  val InitialScrollContextKeywords = List("0", "initial", "start", "first")
 
   val DraftApiHost = propOrElse("DRAFT_API_HOST", "draft-api.ndla-local")
   val TopicAPIUrl = "http://api.topic.ndla.no/rest/v1/keywords/?filter[node]=ndlanode_"

--- a/src/main/scala/no/ndla/imageapi/model/domain/SearchSettings.scala
+++ b/src/main/scala/no/ndla/imageapi/model/domain/SearchSettings.scala
@@ -1,0 +1,13 @@
+package no.ndla.imageapi.model.domain
+
+case class SearchSettings(
+    query: Option[String],
+    minimumSize: Option[Int],
+    language: Option[String],
+    license: Option[String],
+    sort: Sort.Value,
+    page: Option[Int],
+    pageSize: Option[Int],
+    includeCopyrighted: Boolean,
+    shouldScroll: Boolean
+)

--- a/src/test/scala/no/ndla/imageapi/controller/ImageControllerV2Test.scala
+++ b/src/test/scala/no/ndla/imageapi/controller/ImageControllerV2Test.scala
@@ -88,14 +88,7 @@ class ImageControllerV2Test extends UnitSuite with ScalatraSuite with TestEnviro
     val expectedBody = """{"totalCount":0,"page":1,"pageSize":10,"language":"nb","results":[]}"""
     val domainSearchResult = domain.SearchResult(0, Some(1), 10, "nb", List(), None)
     val apiSearchResult = SearchResult(0, Some(1), 10, "nb", List())
-    when(
-      searchService.all(Option(any[Int]),
-                        Option(any[String]),
-                        Option(any[String]),
-                        any[Sort.Value],
-                        Option(any[Int]),
-                        Option(any[Int]),
-                        any[Boolean])).thenReturn(Success(domainSearchResult))
+    when(searchService.matchingQuery(any[SearchSettings])).thenReturn(Success(domainSearchResult))
     when(searchConverterService.asApiSearchResult(domainSearchResult)).thenReturn(apiSearchResult)
     get("/") {
       status should equal(200)
@@ -119,15 +112,7 @@ class ImageControllerV2Test extends UnitSuite with ScalatraSuite with TestEnviro
       """{"totalCount":1,"page":1,"pageSize":10,"language":"nb","results":[{"id":"4","title":{"title":"Tittel","language":"nb"},"contributors":["Jason Bourne","Ben Affleck"],"altText":{"alttext":"AltText","language":"nb"},"previewUrl":"http://image-api.ndla-local/image-api/raw/4","metaUrl":"http://image-api.ndla-local/image-api/v2/images/4","license":"by-sa","supportedLanguages":["nb"]}]}"""
     val domainSearchResult = domain.SearchResult(1, Some(1), 10, "nb", List(imageSummary), None)
     val apiSearchResult = api.SearchResult(1, Some(1), 10, "nb", List(imageSummary))
-    when(
-      searchService.all(Option(any[Int]),
-                        Option(any[String]),
-                        Option(any[String]),
-                        any[Sort.Value],
-                        Option(any[Int]),
-                        Option(any[Int]),
-                        any[Boolean]))
-      .thenReturn(Success(domainSearchResult))
+    when(searchService.matchingQuery(any[SearchSettings])).thenReturn(Success(domainSearchResult))
     when(searchConverterService.asApiSearchResult(domainSearchResult)).thenReturn(apiSearchResult)
     get("/") {
       status should equal(200)
@@ -300,17 +285,7 @@ class ImageControllerV2Test extends UnitSuite with ScalatraSuite with TestEnviro
       Seq.empty,
       Some(scrollId)
     )
-    when(
-      searchService.all(
-        any[Option[Int]],
-        any[Option[String]],
-        any[Option[String]],
-        any[Sort.Value],
-        any[Option[Int]],
-        any[Option[Int]],
-        any[Boolean]
-      ))
-      .thenReturn(Success(searchResponse))
+    when(searchService.matchingQuery(any[SearchSettings])).thenReturn(Success(searchResponse))
 
     get(s"/") {
       status should be(200)
@@ -338,25 +313,7 @@ class ImageControllerV2Test extends UnitSuite with ScalatraSuite with TestEnviro
       status should be(200)
     }
 
-    verify(searchService, times(0)).all(
-      any[Option[Int]],
-      any[Option[String]],
-      any[Option[String]],
-      any[Sort.Value],
-      any[Option[Int]],
-      any[Option[Int]],
-      any[Boolean]
-    )
-    verify(searchService, times(0)).matchingQuery(
-      any[String],
-      any[Option[Int]],
-      any[Option[String]],
-      any[Option[String]],
-      any[Sort.Value],
-      any[Option[Int]],
-      any[Option[Int]],
-      any[Boolean]
-    )
+    verify(searchService, times(0)).matchingQuery(any[SearchSettings])
     verify(searchService, times(1)).scroll(eqTo(scrollId), any[String])
   }
 
@@ -379,25 +336,7 @@ class ImageControllerV2Test extends UnitSuite with ScalatraSuite with TestEnviro
       status should be(200)
     }
 
-    verify(searchService, times(0)).all(
-      any[Option[Int]],
-      any[Option[String]],
-      any[Option[String]],
-      any[Sort.Value],
-      any[Option[Int]],
-      any[Option[Int]],
-      any[Boolean]
-    )
-    verify(searchService, times(0)).matchingQuery(
-      any[String],
-      any[Option[Int]],
-      any[Option[String]],
-      any[Option[String]],
-      any[Sort.Value],
-      any[Option[Int]],
-      any[Option[Int]],
-      any[Boolean]
-    )
+    verify(searchService, times(0)).matchingQuery(any[SearchSettings])
     verify(searchService, times(1)).scroll(eqTo(scrollId), any[String])
   }
 


### PR DESCRIPTION
Related to NDLANO/Issues#2226