### PR TITLE
#2434: Fix search-context=initial (++)

### DIFF
--- a/src/main/scala/no/ndla/imageapi/controller/ImageControllerV2.scala
+++ b/src/main/scala/no/ndla/imageapi/controller/ImageControllerV2.scala
@@ -143,14 +143,14 @@ trait ImageControllerV2 {
       */
     private def scrollSearchOr(scrollId: Option[String], language: String)(orFunction: => Any): Any =
       scrollId match {
-        case Some(scroll) =>
+        case Some(scroll) if !InitialScrollContextKeywords.contains(scroll) =>
           imageSearchService.scroll(scroll, language) match {
             case Success(scrollResult) =>
               val responseHeader = scrollResult.scrollId.map(i => this.scrollId.paramName -> i).toMap
               Ok(searchConverterService.asApiSearchResult(scrollResult), headers = responseHeader)
             case Failure(ex) => errorHandler(ex)
           }
-        case None => orFunction
+        case _ => orFunction
       }
 
     private def search(

--- a/src/test/scala/no/ndla/imageapi/TestData.scala
+++ b/src/test/scala/no/ndla/imageapi/TestData.scala
@@ -238,4 +238,16 @@ object TestData {
     Some("http://www.scanpix.no"),
     List.empty
   )
+
+  val searchSettings = SearchSettings(
+    query = None,
+    minimumSize = None,
+    language = None,
+    license = None,
+    sort = Sort.ByIdAsc,
+    page = None,
+    pageSize = None,
+    includeCopyrighted = false,
+    shouldScroll = false
+  )
 }

--- a/src/test/scala/no/ndla/imageapi/service/search/ImageSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/imageapi/service/search/ImageSearchServiceTest.scala
@@ -14,6 +14,7 @@ import no.ndla.imageapi.ImageApiProperties.{DefaultPageSize, MaxPageSize}
 import no.ndla.imageapi.integration.{Elastic4sClientFactory, NdlaE4sClient}
 import no.ndla.imageapi.model.api
 import no.ndla.imageapi.model.domain._
+import no.ndla.imageapi.TestData.searchSettings
 import no.ndla.imageapi.{ImageApiProperties, TestEnvironment, UnitSuite}
 import no.ndla.mapping.License.{CC_BY_NC_SA, PublicDomain}
 import no.ndla.network.ApplicationUrl
@@ -146,18 +147,6 @@ class ImageSearchServiceTest
     Seq(),
     "ndla124",
     updated
-  )
-
-  val searchSettings = SearchSettings(
-    query = None,
-    minimumSize = None,
-    language = None,
-    license = None,
-    sort = Sort.ByIdAsc,
-    page = None,
-    pageSize = None,
-    includeCopyrighted = false,
-    shouldScroll = false
   )
 
   override def beforeAll(): Unit = {


### PR DESCRIPTION
Relates to NDLANO/Issues#2434

Fikser så søk med search-context=initial (og de andre) fungerer som forventet og returnerer en search-context header
Søk uten search-context returnerer ingenting