### PR TITLE
#2413 raw endepunktet returnerer ikke 404

### DIFF
--- a/src/main/scala/no/ndla/imageapi/controller/RawController.scala
+++ b/src/main/scala/no/ndla/imageapi/controller/RawController.scala
@@ -83,7 +83,8 @@ trait RawController {
           )
           .responseMessages(response404, response500))
     ) {
-      imageRepository.withId(long("image_id")) match {
+      val imageId = long("image_id")
+      imageRepository.withId(imageId) match {
         case Some(imageMeta) =>
           val imageName = Uri
             .parse(imageMeta.imageUrl)
@@ -94,7 +95,7 @@ trait RawController {
             case Failure(ex)  => errorHandler(ex)
             case Success(img) => Ok(img)
           }
-        case None => None
+        case None => halt(status = 404, body = Error(Error.NOT_FOUND, s"Image with id $imageId not found"))
       }
     }
 


### PR DESCRIPTION
Fixes NDLANO/Issues#2413

Når ImageRepository gir None på en id håndteres det nå på samme måte i RawController som i ImageControllerV2 med 404 og relativt like feilmeldinger.

- F.eks. id= 53918 skal gi 404