### PR TITLE
#2719: Adds `not-set` default value to `modelReleased` field

### DIFF
--- a/src/main/scala/db/migration/V10__DefaultModelReleasedToNotSet.scala
+++ b/src/main/scala/db/migration/V10__DefaultModelReleasedToNotSet.scala
@@ -1,0 +1,61 @@
+/*
+ * Part of NDLA image-api.
+ * Copyright (C) 2021 NDLA
+ *
+ * See LICENSE
+ */
+
+package db.migration
+
+import no.ndla.imageapi.model.domain.ModelReleasedStatus
+import org.flywaydb.core.api.migration.{BaseJavaMigration, Context}
+import org.json4s.JsonAST.{JField, JString}
+import org.json4s.native.JsonMethods.{compact, parse, render}
+import org.json4s.{DefaultFormats, JArray, JObject}
+import org.postgresql.util.PGobject
+import scalikejdbc.{DB, DBSession, _}
+
+class V10__DefaultModelReleasedToNotSet extends BaseJavaMigration {
+
+  implicit val formats: DefaultFormats.type = org.json4s.DefaultFormats
+  val timeService = new TimeService()
+
+  override def migrate(context: Context) = {
+    val db = DB(context.getConnection)
+    db.autoClose(false)
+
+    db.withinTx { implicit session =>
+      imagesToUpdate.map {
+        case (id, document) => update(convertImageUpdate(document), id)
+      }
+    }
+  }
+
+  def imagesToUpdate(implicit session: DBSession): List[(Long, String)] = {
+    sql"select id, metadata from imagemetadata"
+      .map(rs => {
+        (rs.long("id"), rs.string("metadata"))
+      })
+      .list()
+      .apply()
+  }
+
+  def convertImageUpdate(imageMeta: String): String = {
+    val oldDocument = parse(imageMeta)
+
+    val mergeObject = JObject(
+      JField("modelReleased", JString(ModelReleasedStatus.NOT_SET.toString)),
+    )
+
+    val mergedDoc = oldDocument.merge(mergeObject)
+    compact(render(mergedDoc))
+  }
+
+  def update(imagemetadata: String, id: Long)(implicit session: DBSession) = {
+    val dataObject = new PGobject()
+    dataObject.setType("jsonb")
+    dataObject.setValue(imagemetadata)
+
+    sql"update imagemetadata set metadata = ${dataObject} where id = $id".update().apply()
+  }
+}

--- a/src/main/scala/no/ndla/imageapi/model/api/ImageMetaInformationV2.scala
+++ b/src/main/scala/no/ndla/imageapi/model/api/ImageMetaInformationV2.scala
@@ -23,6 +23,6 @@ case class ImageMetaInformationV2(
     @(ApiModelProperty @field)(description = "Supported languages for the image title, alt-text, tags and caption.") supportedLanguages: Seq[String],
     @(ApiModelProperty @field)(description = "Describes when the image was created") created: Date,
     @(ApiModelProperty @field)(description = "Describes who created the image") createdBy: String,
-    @(ApiModelProperty @field)(description = "Describes if the model has released use of the image", allowableValues = "yes,no,not-applicable") modelRelease: String,
+    @(ApiModelProperty @field)(description = "Describes if the model has released use of the image", allowableValues = "not-set,yes,no,not-applicable") modelRelease: String,
     @(ApiModelProperty @field)(description = "Describes the changes made to the image, only visible to editors") editorNotes: Option[Seq[EditorNote]]
 )

--- a/src/main/scala/no/ndla/imageapi/model/api/ImageMetaSummary.scala
+++ b/src/main/scala/no/ndla/imageapi/model/api/ImageMetaSummary.scala
@@ -16,6 +16,6 @@ case class ImageMetaSummary(
     @(ApiModelProperty @field)(description = "The full url to where the complete metainformation about the image can be found") metaUrl: String,
     @(ApiModelProperty @field)(description = "Describes the license of the image") license: String,
     @(ApiModelProperty @field)(description = "List of supported languages in priority") supportedLanguages: Seq[String],
-    @(ApiModelProperty @field)(description = "Describes if the model has released use of the image", allowableValues = "yes,no,not-applicable") modelRelease: Option[String],
+    @(ApiModelProperty @field)(description = "Describes if the model has released use of the image", allowableValues = "not-set,yes,no,not-applicable") modelRelease: Option[String],
     @(ApiModelProperty @field)(description = "Describes the changes made to the image, only visible to editors") editorNotes: Option[Seq[String]]
 )

--- a/src/main/scala/no/ndla/imageapi/model/api/NewImageMetaInformationV2.scala
+++ b/src/main/scala/no/ndla/imageapi/model/api/NewImageMetaInformationV2.scala
@@ -21,5 +21,5 @@ case class NewImageMetaInformationV2(
     @(ApiModelProperty @field)(description = "Searchable tags for the image") tags: Seq[String],
     @(ApiModelProperty @field)(description = "Caption for the image") caption: String,
     @(ApiModelProperty @field)(description = "ISO 639-1 code that represents the language used in the caption") language: String,
-    @(ApiModelProperty @field)(description = "Describes if the model has released use of the image, allowed values are 'yes', 'no', and 'not-applicable', defaults to 'no'", allowableValues = "yes,no,not-applicable") modelReleased: Option[String]
+    @(ApiModelProperty @field)(description = "Describes if the model has released use of the image, allowed values are 'not-set', 'yes', 'no', and 'not-applicable', defaults to 'no'", allowableValues = "yes,no,not-applicable") modelReleased: Option[String]
 )

--- a/src/main/scala/no/ndla/imageapi/model/domain/ImageApiModels.scala
+++ b/src/main/scala/no/ndla/imageapi/model/domain/ImageApiModels.scala
@@ -48,6 +48,7 @@ object ModelReleasedStatus extends Enumeration {
   val YES = Value("yes")
   val NO = Value("no")
   val NOT_APPLICABLE = Value("not-applicable")
+  val NOT_SET = Value("not-set")
 
   def valueOfOrError(s: String): Try[this.Value] =
     valueOf(s) match {

--- a/src/main/scala/no/ndla/imageapi/service/ConverterService.scala
+++ b/src/main/scala/no/ndla/imageapi/service/ConverterService.scala
@@ -176,7 +176,7 @@ trait ConverterService {
                                        image: domain.Image): Try[domain.ImageMetaInformation] = {
       val modelReleasedStatus = imageMeta.modelReleased match {
         case Some(mrs) => ModelReleasedStatus.valueOfOrError(mrs)
-        case None      => Success(ModelReleasedStatus.NO)
+        case None      => Success(ModelReleasedStatus.NOT_SET)
       }
 
       modelReleasedStatus.map(modelStatus => {


### PR DESCRIPTION
NDLANO/Issues#2719

Kan testes ved å spinne opp lokal image-api og sjekke at `modelReleased` verdi `not-set` er default, og alle eksisterende bilder blir migrert til denne. :smile: