### PR TITLE
#2709: Extend image log with add/delete language and update imagefile

### DIFF
--- a/src/main/scala/no/ndla/imageapi/service/ConverterService.scala
+++ b/src/main/scala/no/ndla/imageapi/service/ConverterService.scala
@@ -165,10 +165,14 @@ trait ConverterService {
     }
 
     def withNewImage(imageMeta: domain.ImageMetaInformation, image: domain.Image) = {
+      val user = authUser.userOrClientid()
+      val now = clock.now()
+      val newNote = domain.EditorNote(now, user, "Updated image file.")
       imageMeta.copy(
         imageUrl = Uri.parse(image.fileName).toString,
         size = image.size,
-        contentType = image.contentType
+        contentType = image.contentType,
+        editorNotes = imageMeta.editorNotes :+ newNote
       )
     }
 
@@ -237,13 +241,19 @@ trait ConverterService {
     }
 
     def withoutLanguage(domainMetaInformation: domain.ImageMetaInformation,
-                        languageToRemove: String): domain.ImageMetaInformation =
+                        languageToRemove: String): domain.ImageMetaInformation = {
+      val now = clock.now()
+      val userId = authUser.userOrClientid()
       domainMetaInformation.copy(
         titles = domainMetaInformation.titles.filterNot(_.language == languageToRemove),
         alttexts = domainMetaInformation.alttexts.filterNot(_.language == languageToRemove),
         tags = domainMetaInformation.tags.filterNot(_.language == languageToRemove),
         captions = domainMetaInformation.captions.filterNot(_.language == languageToRemove),
+        editorNotes = domainMetaInformation.editorNotes :+ domain.EditorNote(now,
+                                                                             userId,
+                                                                             s"Deleted language '$languageToRemove'.")
       )
+    }
 
     def getSupportedLanguages(domainImageMetaInformation: domain.ImageMetaInformation): Seq[String] = {
       findSupportedLanguages(

--- a/src/main/scala/no/ndla/imageapi/service/WriteService.scala
+++ b/src/main/scala/no/ndla/imageapi/service/WriteService.scala
@@ -124,7 +124,11 @@ trait WriteService {
       val now = clock.now()
       val userId = authUser.userOrClientid()
 
-      val newEditorNote = domain.EditorNote(now, userId, "Image updated.")
+      val existingLanguages = converterService.getSupportedLanguages(existing)
+      val isNewLanguage = !existingLanguages.contains(toMerge.language)
+      val newEditorNote =
+        if (isNewLanguage) domain.EditorNote(now, userId, s"Added new language '${toMerge.language}'.")
+        else domain.EditorNote(now, userId, "Image updated.")
 
       existing.copy(
         titles = mergeLanguageFields(existing.titles,

--- a/src/test/scala/no/ndla/imageapi/TestData.scala
+++ b/src/test/scala/no/ndla/imageapi/TestData.scala
@@ -24,7 +24,6 @@ import org.joda.time.{DateTime, DateTimeZone}
 object TestData {
 
   def updated() = (new DateTime(2017, 4, 1, 12, 15, 32, DateTimeZone.UTC)).toDate
-  "2017"
 
   val ByNcSa = mapping.License.CC_BY_NC_SA.toString
 

--- a/src/test/scala/no/ndla/imageapi/service/WriteServiceTest.scala
+++ b/src/test/scala/no/ndla/imageapi/service/WriteServiceTest.scala
@@ -282,7 +282,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     val expectedResult = existing.copy(
       titles = List(existing.titles.head, domain.ImageTitle("Title", "en")),
       alttexts = List(existing.alttexts.head, domain.ImageAltText("AltText", "en")),
-      editorNotes = Seq(domain.EditorNote(date, user, "Image updated."))
+      editorNotes = Seq(domain.EditorNote(date, user, "Added new language 'en'."))
     )
 
     when(authUser.userOrClientid()).thenReturn(user)
@@ -391,10 +391,19 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     reset(imageIndexService)
     reset(tagIndexService)
 
+    val date = new Date()
+    val user = "ndla124"
+
+    when(authUser.userOrClientid()).thenReturn(user)
+    when(clock.now()).thenReturn(date)
+
     val imageId = 5555.toLong
     val image = multiLangImage.copy(id = Some(imageId))
     val expectedImage =
-      image.copy(titles = List(domain.ImageTitle("english", "en"), domain.ImageTitle("norsk", "unknown")))
+      image.copy(
+        titles = List(domain.ImageTitle("english", "en"), domain.ImageTitle("norsk", "unknown")),
+        editorNotes = image.editorNotes :+ domain.EditorNote(date, user, "Deleted language 'nn'.")
+      )
 
     when(imageRepository.withId(imageId)).thenReturn(Some(image))
     when(imageRepository.update(any[domain.ImageMetaInformation], eqTo(imageId))).thenAnswer((i: InvocationOnMock) =>


### PR DESCRIPTION
Fixes NDLANO/Issues#2709


Kan testes ved å spinne opp lokalt og legge til et språk, slette et språk og endre bildefil til et bilde og sjekke at det dukker opp i loggen.

Om noen har forslag til flere ting vi burde logges å fyr løs.
Det er _mulig_ å vise oppdaterte enkelt felter i metadataen, men det må nok gjøres ganske manuelt (eller med skummel reflection) og kanskje litt stress å vedlikeholde, så om ndla ikke trenger det så burde vi kanskje unngå det.