### PR TITLE
#2739: Handle unsupported languages in search

### DIFF
--- a/src/main/scala/no/ndla/imageapi/model/Language.scala
+++ b/src/main/scala/no/ndla/imageapi/model/Language.scala
@@ -24,6 +24,7 @@ object Language {
     LanguageAnalyzer("de", GermanLanguageAnalyzer),
     LanguageAnalyzer("es", SpanishLanguageAnalyzer),
     LanguageAnalyzer("se", StandardAnalyzer), // SAMI
+    LanguageAnalyzer("sma", StandardAnalyzer), // SAMI
     LanguageAnalyzer("zh", ChineseLanguageAnalyzer),
     LanguageAnalyzer(UnknownLanguage, NorwegianLanguageAnalyzer)
   )

--- a/src/main/scala/no/ndla/imageapi/service/search/ImageSearchService.scala
+++ b/src/main/scala/no/ndla/imageapi/service/search/ImageSearchService.scala
@@ -39,7 +39,7 @@ trait ImageSearchService {
     override val searchIndex = ImageApiProperties.SearchIndex
     override val indexService = imageIndexService
 
-    def hitToApiModel(hit: String, language: Option[String]): ImageMetaSummary = {
+    def hitToApiModel(hit: String, language: String): ImageMetaSummary = {
       implicit val formats: Formats = SearchableLanguageFormats.JSonFormats
       searchConverterService.asImageMetaSummary(read[SearchableImage](hit), language)
     }
@@ -113,8 +113,8 @@ trait ImageSearchService {
       }
 
       val (languageFilter, searchLanguage) = settings.language match {
-        case None | Some(Language.AllLanguages) => (None, "*")
-        case Some(lang)                         => (Some(existsQuery(s"titles.$lang")), lang)
+        case Some(lang) if Language.supportedLanguages.contains(lang) => (Some(existsQuery(s"titles.$lang")), lang)
+        case _                                                        => (None, "*")
       }
 
       val modelReleasedFilter = Option.when(settings.modelReleased.nonEmpty)(
@@ -154,7 +154,7 @@ trait ImageSearchService {
                 Some(settings.page.getOrElse(1)),
                 numResults,
                 if (searchLanguage == "*") Language.AllLanguages else searchLanguage,
-                getHits(response.result, settings.language),
+                getHits(response.result, searchLanguage),
                 response.result.scrollId
               ))
           case Failure(ex) => errorHandler(ex)

--- a/src/main/scala/no/ndla/imageapi/service/search/SearchConverterService.scala
+++ b/src/main/scala/no/ndla/imageapi/service/search/SearchConverterService.scala
@@ -75,14 +75,14 @@ trait SearchConverterService {
       )
     }
 
-    def asImageMetaSummary(searchableImage: SearchableImage, language: Option[String]): ImageMetaSummary = {
+    def asImageMetaSummary(searchableImage: SearchableImage, language: String): ImageMetaSummary = {
       val apiToRawRegex = "/v\\d+/images/".r
       val title = Language
-        .findByLanguageOrBestEffort(searchableImage.titles.languageValues, language)
+        .findByLanguageOrBestEffort(searchableImage.titles.languageValues, Some(language))
         .map(res => ImageTitle(res.value, res.language))
         .getOrElse(ImageTitle("", DefaultLanguage))
       val altText = Language
-        .findByLanguageOrBestEffort(searchableImage.alttexts.languageValues, language)
+        .findByLanguageOrBestEffort(searchableImage.alttexts.languageValues, Some(language))
         .map(res => ImageAltText(res.value, res.language))
         .getOrElse(ImageAltText("", DefaultLanguage))
 


### PR DESCRIPTION
NDLANO/Issues#2739

Kan testes ved å søke på tom-query mot et språk som ikke er støttet (Og teste at `sma` er støttet).